### PR TITLE
Fake V1 responses the V2 API doesn't return

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+pytest
+pytest-cov
 setuptools==65.5.1
 load_dotenv>=0.1.0
 sonnen_api_v2>=0.5.11

--- a/sonnenbatterie/sonnenbatterie.py
+++ b/sonnenbatterie/sonnenbatterie.py
@@ -1,4 +1,4 @@
-#import os
+import os
 #import hashlib
 import requests
 import json
@@ -7,11 +7,13 @@ from .const import *
 # pylint: enable=unused-wildcard-import
 from .timeofuse import timeofuseschedule
 from sonnen_api_v2 import Sonnen
+from dotenv import load_dotenv
 
 # indexes for _batteryRequestTimeout
 TIMEOUT_CONNECT=0
 TIMEOUT_REQUEST=1
 
+load_dotenv()
 
 class sonnenbatterie:
 
@@ -28,6 +30,8 @@ class sonnenbatterie:
         self._batteryRequestTimeout = (DEFAULT_CONNECT_TO_BATTERY_TIMEOUT, DEFAULT_READ_FROM_BATTERY_TIMEOUT)
         self._battery = Sonnen(self.token, self.ipaddress)
         self._battery.set_request_connect_timeouts(self._batteryRequestTimeout)
+        self._battery_serial_number = os.getenv("BATTERIE_SN", "unknown")
+        self._battery_model = os.getenv("BATTERIE_MODEL", "unknown")
 
 #        self._login()
 
@@ -139,16 +143,27 @@ class sonnenbatterie:
         return self._battery.get_powermeter()
 
     def get_batterysystem(self):
+        '''battery_system not in V2 - fake it for required component attributes'''
     #    return self._get(SONNEN_API_PATH_BATTERY_SYSTEM)
-        raise ValueError('System Data endpoint not defined for V2 API')
+        configurations = self._battery.get_configurations()
+        systemdata = {'modules': configurations.get('IC_BatteryModules'),
+                      'battery_system': {'system': {'storage_capacity_per_module': configurations.get('CM_MarketingModuleCapacity') }}
+                    }
+        return systemdata
 
     def get_inverter(self):
     #    return self._get(SONNEN_API_PATH_INVERTER)
         return self._battery.get_inverter()
 
     def get_systemdata(self):
+        '''system_data not in V2 - fake it for required component attributes'''
+        configurations = self._battery.get_configurations()
+        systemdata = {'software_version': configurations.get("DE_Software"),
+                      'ERP_ArticleName': self._battery_model,
+                      'DE_Ticket_Number': self._battery_serial_number
+                    }
     #    return self._get(SONNEN_API_PATH_SYSTEM_DATA)
-        raise ValueError('System Data endpoint not defined for V2 API')
+        return systemdata
 
     def get_status(self):
     #    return self._get(SONNEN_API_PATH_STATUS)
@@ -169,7 +184,6 @@ class sonnenbatterie:
     def get_configuration(self, name):
     #    return self._get(SONNEN_API_PATH_CONFIGURATIONS+"/"+name).get(name)
         return self._battery.get_configurations().get(name)
-
 
     # these have special handling in some form, for example converting a mode as a number into a string
     def get_current_charge_level(self):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,1 +1,1 @@
-from sonnenbatterie import sonnenbatterie
+#from sonnenbatterie import sonnenbatterie

--- a/test/test_battery_devinfo.py
+++ b/test/test_battery_devinfo.py
@@ -1,0 +1,116 @@
+"""Verify package sonnenbatterie V2 API used by sonnenbatterie component works."""
+
+import os
+
+from dotenv import load_dotenv
+from sonnenbatterie import sonnenbatterie
+
+DOMAIN = "sonnenbatterie" # from sonnenbatterie.const import
+
+load_dotenv()
+
+BATTERIE_HOST = os.getenv("BATTERIE_HOST", "X")
+API_READ_TOKEN = os.getenv("API_READ_TOKEN", "X")
+API_WRITE_TOKEN = os.getenv("API_WRITE_TOKEN", "X")
+
+if BATTERIE_HOST == "X" or (API_WRITE_TOKEN == "X" and API_READ_TOKEN == "X"):
+    print(f"host: {BATTERIE_HOST} WRITE: {API_WRITE_TOKEN} READ: {API_READ_TOKEN}")
+    raise ValueError(
+        "Set BATTERIE_HOST & API_READ_TOKEN or API_WRITE_TOKEN in .env See env.example"
+    )
+
+
+def test_devinfo() -> None:
+    _battery = sonnenbatterie(
+        "", API_WRITE_TOKEN if API_WRITE_TOKEN != "X" else API_READ_TOKEN, BATTERIE_HOST
+    )
+    assert _battery is not False
+    system_data = _battery.get_systemdata()
+    print(f'system_data type: {type(system_data)}')
+    model = system_data.get("ERP_ArticleName", "unknown")
+    name=f"{DOMAIN} {system_data.get('DE_Ticket_Number', 'unknown')}"
+    sw_version = system_data.get("software_version", "unknown")
+    print(f"model: {model}  name: {name}  sw_version: {sw_version}")
+    assert system_data.get('DE_Ticket_Number') == '263291'
+
+def test_batterysystem() -> None:
+    _battery = sonnenbatterie(
+        "", API_WRITE_TOKEN if API_WRITE_TOKEN != "X" else API_READ_TOKEN, BATTERIE_HOST
+    )
+    assert _battery is not False
+    latestData = {}
+    # code syntax from custom_component coordinator.py
+    latestData["battery_system"] = _battery.get_batterysystem()
+    batt_module_capacity = int(
+        latestData["battery_system"]["battery_system"]["system"][
+            "storage_capacity_per_module"
+        ]
+    )
+    assert batt_module_capacity == 5000
+    batt_module_count = int(latestData["battery_system"]["modules"])
+    assert batt_module_count == 2
+
+def test_powermeter() -> None:
+    _battery = sonnenbatterie(
+        "", API_WRITE_TOKEN if API_WRITE_TOKEN != "X" else API_READ_TOKEN, BATTERIE_HOST
+    )
+    assert _battery is not False
+    latestData = {}
+    # code syntax from custom_component coordinator.py
+    latestData["powermeter"] = _battery.get_powermeter()
+    print(f'powermeter type: {type(latestData["powermeter"])}')
+    if(isinstance(latestData["powermeter"],dict)):
+        newPowerMeters=[]
+        for index,dictIndex in enumerate(latestData["powermeter"]):
+            newPowerMeters.append(latestData["powermeter"][dictIndex])
+        print(f'new powermeters: {newPowerMeters}')
+
+def test_status() -> None:
+    _battery = sonnenbatterie(
+        "", API_WRITE_TOKEN if API_WRITE_TOKEN != "X" else API_READ_TOKEN, BATTERIE_HOST
+    )
+    assert _battery is not False
+    latestData = {}
+    # code syntax from custom_component coordinator.py
+    latestData["status"] = _battery.get_status()
+    print(f'status type: {type(latestData["status"])}')
+    if latestData["status"]["BatteryCharging"]:
+        battery_current_state = "charging"
+    elif latestData["status"]["BatteryDischarging"]:
+        battery_current_state = "discharging"
+    else:
+        battery_current_state = "standby"
+    RSOC = latestData["status"]["RSOC"]
+    print(f'battery_state: {battery_current_state}  RSOC: {RSOC}%')
+
+def test_batteryinfo() -> None:
+    _battery = sonnenbatterie(
+        "", API_WRITE_TOKEN if API_WRITE_TOKEN != "X" else API_READ_TOKEN, BATTERIE_HOST
+    )
+    assert _battery is not False
+    latestData = {}
+    # code syntax from custom_component coordinator.py
+        # fixed value, percentage of total installed power reserved for
+        # internal battery system purposes
+    batt_reserved_factor = 7.0
+    latestData["battery_system"] = _battery.get_batterysystem()
+    print(f'battery_system type: {type(latestData["battery_system"])}')
+    latestData["status"] = _battery.get_status()
+    print(f'status type: {type(latestData["status"])}')
+    batt_module_capacity = int(
+        latestData["battery_system"]["battery_system"]["system"][
+            "storage_capacity_per_module"
+        ]
+    )
+    batt_module_count = int(latestData["battery_system"]["modules"])
+    print(f'module_capacity: {batt_module_capacity:,}Wh  module_count: {batt_module_count}')
+    total_installed_capacity = int(batt_module_count * batt_module_capacity)
+    reserved_capacity = int(
+            total_installed_capacity * (batt_reserved_factor / 100.0)
+        )
+    remaining_capacity = (
+            int(total_installed_capacity * latestData["status"]["RSOC"]) / 100.0
+        )
+    remaining_capacity_usable = max(
+            0, int(remaining_capacity - reserved_capacity))
+    print(f'remaining_capacity_usable: {remaining_capacity_usable:,}Wh')

--- a/test/test_battery_reserve.py
+++ b/test/test_battery_reserve.py
@@ -1,3 +1,5 @@
+"""pytest tests/test_battey_reserve.py -s -x -v """
+
 import os, sys
 import unittest
 import json


### PR DESCRIPTION
 - use dotenv for (fixed) inaccessible V1 values
 - test every value used by custom_component sonnenbatterie coordinator